### PR TITLE
[JBPM-9151] Fix some tests removing unit when undeploy

### DIFF
--- a/jbpm-services/jbpm-kie-services/src/test/java/org/jbpm/kie/services/test/BPMN2DataServicesTest.java
+++ b/jbpm-services/jbpm-kie-services/src/test/java/org/jbpm/kie/services/test/BPMN2DataServicesTest.java
@@ -347,6 +347,7 @@ public class BPMN2DataServicesTest extends AbstractKieServicesBaseTest {
 
         // now let's undeploy the unit
         deploymentService.undeploy(deploymentUnit);
+        units.remove(deploymentUnit);
 
         try {
             bpmn2Service.getProcessDefinition(deploymentUnit.getIdentifier(), processId);
@@ -399,6 +400,7 @@ public class BPMN2DataServicesTest extends AbstractKieServicesBaseTest {
         deploymentService.deploy(deploymentUnit);
         units.add(deploymentUnit);
         deploymentService.undeploy(deploymentUnit);
+        units.remove(deploymentUnit);
         bpmn2Service.getProcessDefinition(deploymentUnit.getIdentifier(), "org.jbpm.writedocument");
     }
 

--- a/jbpm-services/jbpm-kie-services/src/test/java/org/jbpm/kie/services/test/DeploymentServiceWithSyncTest.java
+++ b/jbpm-services/jbpm-kie-services/src/test/java/org/jbpm/kie/services/test/DeploymentServiceWithSyncTest.java
@@ -210,6 +210,7 @@ public class DeploymentServiceWithSyncTest extends AbstractKieServicesBaseTest {
 		deployed = deploymentService.getDeployedUnits();
     	assertNotNull(deployed);
     	assertEquals(0, deployed.size());
+    	units.remove(unit);
     }
     
     @Test
@@ -261,7 +262,6 @@ public class DeploymentServiceWithSyncTest extends AbstractKieServicesBaseTest {
     	unit.addAttribute("sync", "false");
     	
     	store.enableDeploymentUnit(unit);
-		units.add(unit);
 		
 		countDownListener.waitTillCompleted(4000);
 		


### PR DESCRIPTION
Missing this failing test: FilteredKModuleDeploymentServiceTest#testSerializationClassesLimitedInDeploymentDescriptor.

I think there's a bug, because deploymentUnit still deployed (org.test:jbpm-kie-services-filter-test-desc:1.0.0), and however deploymentIds is empty.