### PR TITLE
Include traces about timers and runtime manager

### DIFF
--- a/jbpm-human-task/jbpm-human-task-core/src/main/java/org/jbpm/services/task/impl/TaskDeadlinesServiceImpl.java
+++ b/jbpm-human-task/jbpm-human-task-core/src/main/java/org/jbpm/services/task/impl/TaskDeadlinesServiceImpl.java
@@ -90,6 +90,12 @@ public class TaskDeadlinesServiceImpl implements TaskDeadlinesService {
         String deploymentId = task.getTaskData().getDeploymentId();
 
         TimerService timerService = TimerServiceRegistry.getInstance().get(deploymentId + TimerServiceRegistry.TIMER_SERVICE_SUFFIX);
+        logger.debug("deploymentId: "+ deploymentId + "\ntimerService: "+ timerService + "\ntaskId:"+ taskId + "\ndeadlineId: "+deadlineId +  "\ndelay: "+ delay + "\ntype: "+ type+"\n");
+        try {
+           throw new Exception("call stack");
+        } catch (Exception e) {
+            logger.trace("call stack: ", e);
+        }
         if (timerService != null && timerService instanceof GlobalTimerService) {
             TaskDeadlineJob deadlineJob = new TaskDeadlineJob(taskId, deadlineId, type, deploymentId, task.getTaskData().getProcessInstanceId());
             Trigger trigger = new IntervalTrigger( timerService.getCurrentTime(),
@@ -105,6 +111,7 @@ public class TaskDeadlinesServiceImpl implements TaskDeadlinesService {
             jobHandles.put(deadlineJob.getId(), handle);
 
         } else {
+            logger.debug( "scheduling timer job with future: task {}", taskId);
             ScheduledFuture<ScheduledTaskDeadline> scheduled = scheduler.schedule(new ScheduledTaskDeadline(taskId, deadlineId, type, deploymentId, task.getTaskData().getProcessInstanceId()), delay, TimeUnit.MILLISECONDS);
             
             List<ScheduledFuture<ScheduledTaskDeadline>> knownFutures = null;

--- a/jbpm-runtime-manager/src/main/java/org/jbpm/runtime/manager/impl/RuntimeManagerFactoryImpl.java
+++ b/jbpm-runtime-manager/src/main/java/org/jbpm/runtime/manager/impl/RuntimeManagerFactoryImpl.java
@@ -31,6 +31,8 @@ import org.kie.api.runtime.manager.RuntimeManager;
 import org.kie.api.runtime.manager.RuntimeManagerFactory;
 import org.kie.internal.runtime.manager.SessionFactory;
 import org.kie.internal.runtime.manager.TaskServiceFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * This is the main entry point class for the RuntimeManager module responsible for delivering <code>RuntimeManager</code>
@@ -50,6 +52,7 @@ import org.kie.internal.runtime.manager.TaskServiceFactory;
  */
 public class RuntimeManagerFactoryImpl implements RuntimeManagerFactory {
     
+    private static final Logger logger = LoggerFactory.getLogger(RuntimeManagerFactoryImpl.class);
 
     @Override
     public RuntimeManager newSingletonRuntimeManager(RuntimeEnvironment environment) {
@@ -142,7 +145,9 @@ public class RuntimeManagerFactoryImpl implements RuntimeManagerFactory {
     }
     
     protected void initTimerService(RuntimeEnvironment environment, RuntimeManager manager) {
+        logger.debug("init timer service: " + manager);
         if (environment instanceof SchedulerProvider) {
+            logger.debug("scheduleProvider");
             GlobalSchedulerService schedulerService = ((SchedulerProvider) environment).getSchedulerService();  
             if (schedulerService != null) {
                 TimerService globalTs = new GlobalTimerService(manager, schedulerService);


### PR DESCRIPTION
**JIRA**: 

[RHPAM-3946](https://issues.redhat.com/browse/RHPAM-3946)

**referenced Pull Requests**: 

* [[JBPM-9920] Avoiding race condition between deployment and timer](https://github.com/kiegroup/jbpm/pull/2044)

Include this traces to follow similar scenarios in future.

Possible changes:
- Put all messages on TRACE level
- Avoid new line on messages

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* <b>a pull request</b> please add comment: <b>Jenkins retest this</b>
 
* <b>a full downstream build</b> please add comment: <b>Jenkins run fdb</b>
  
* <b>a compile downstream build</b> please  add comment: <b>Jenkins run cdb</b>

* <b>a full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>

* <b>an upstream build</b> please add comment: <b>Jenkins run upstream</b>
</details>
